### PR TITLE
Remove tooltip on clicking its element

### DIFF
--- a/assets/js/admin/admin-google-map.js
+++ b/assets/js/admin/admin-google-map.js
@@ -1728,7 +1728,8 @@ var gmb_data;
             },
             hide: {
                 fixed: true,
-                delay: 100
+                delay: 100,
+                event: 'mouseleave click'
             },
             position: {
                 my: 'top center',


### PR DESCRIPTION
Fixes https://github.com/WordImpress/Google-Maps-Builder/issues/205