### PR TITLE
Replace WPLANG constant with get_locale()

### DIFF
--- a/includes/admin/system-info.php
+++ b/includes/admin/system-info.php
@@ -100,7 +100,7 @@ function gmb_tools_sysinfo_get() {
 	// WordPress configuration
 	$return .= "\n" . '-- WordPress Configuration' . "\n\n";
 	$return .= 'Version:                  ' . get_bloginfo( 'version' ) . "\n";
-	$return .= 'Language:                 ' . ( defined( 'WPLANG' ) && WPLANG ? WPLANG : 'en_US' ) . "\n";
+	$return .= 'Language:                 ' . get_locale() . "\n";
 	$return .= 'Permalink Structure:      ' . ( get_option( 'permalink_structure' ) ? get_option( 'permalink_structure' ) : 'Default' ) . "\n";
 	$return .= 'Active Theme:             ' . $theme . "\n";
 	$return .= 'Show On Front:            ' . get_option( 'show_on_front' ) . "\n";


### PR DESCRIPTION
Addresses https://github.com/WordImpress/Google-Maps-Builder/issues/254 by replacing the deprecated `WPLANG` constant with `get_locale()`. Note this only addresses language detection on the System Info screen issue and does not actually affect translations.