### PR TITLE
fix(google-maps-builder): Mashup Clustering Isn't Working

### DIFF
--- a/includes/libraries/map-icons/js/map-icons.js
+++ b/includes/libraries/map-icons/js/map-icons.js
@@ -82,10 +82,15 @@ MarkerLabel.prototype.onAdd = function() {
 
 // Marker Label onRemove
 MarkerLabel.prototype.onRemove = function() {
-     this.div.parentNode.removeChild(this.div);
-     for (var i = 0, I = this.listeners.length; i < I; ++i) {
-          google.maps.event.removeListener(this.listeners[i]);
-     }
+	var i;
+	if ( this.div.parentNode ) {
+		this.div.parentNode.removeChild( this.div );
+	} // Remove event listeners:
+	if ( this.listeners ) {
+		for ( i = 0; i < this.listeners.length; i ++ ) {
+			google.maps.event.removeListener( this.listeners[ i ] );
+		}
+	}
 };
 
 // Implement draw


### PR DESCRIPTION
## Description
This PR will fix https://github.com/WordImpress/Google-Maps-Builder/issues/67

## How Has This Been Tested?
Manually tested

## Videos:
https://www.useloom.com/share/349b985284a64bf58096b242600f79d5

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.