### PR TITLE
fix(google-maps-builder): fix- Make CSS stricter to avoid theme conflict

### DIFF
--- a/assets/css/google-maps-builder.css
+++ b/assets/css/google-maps-builder.css
@@ -37,11 +37,12 @@ div[id^='google-maps-builder'] iframe.gm-save-widget {
 
 /* This fixes issues some themes have with embedded Google Maps (like Twenty Twelve) */
 div[id^='google-maps-builder'] img {
-  max-width: none;
-  box-shadow: none;
-  -moz-box-shadow: none;
-  -webkit-box-shadow: none;
-  width: auto; }
+  max-width: none !important;
+  box-shadow: none !important;
+  -moz-box-shadow: none !important;
+  -webkit-box-shadow: none !important;
+  width: auto;
+}
 
 /**
  * Info Bubble (window)

--- a/includes/class-gmc-admin-scripts.php
+++ b/includes/class-gmc-admin-scripts.php
@@ -48,7 +48,7 @@ class Google_Maps_Builder_Core_Admin_Scripts extends Google_Maps_Builder_Core_Sc
 	 */
 	function enqueue_admin_styles( $hook ) {
 
-		global $post;
+		global $current_screen;
 		$suffix = $this->paths->suffix();
 
 		//Only enqueue scripts for CPT on post type screen
@@ -57,7 +57,7 @@ class Google_Maps_Builder_Core_Admin_Scripts extends Google_Maps_Builder_Core_Sc
 			  'post.php' === $hook ||
 			  'edit.php' === $hook )
 			&& (
-				'google_maps' === $post->post_type ||
+				'google_maps' === $current_screen->post_type ||
 				'google_maps_page_gmb_settings' === $hook ||
 				'google_maps_page_gmb_import_export' === $hook
 			)


### PR DESCRIPTION
## Description
This PR will fix https://github.com/WordImpress/Google-Maps-Builder/issues/169

## How Has This Been Tested?
Manually Tested

## Types of changes
 Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.