### PR TITLE
fix: Map theme tooltip re added due to lost while solving conflict

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -614,6 +614,13 @@ function gmb_render_maker_field_tooltip( $id ) {
 				esc_html__( 'Select an animation behaviour for marker for ex: Bounce or Drop', 'google-maps-builder' )
 			);
 			break;
+		case 'render_snazzy_tooltip':
+			return sprintf( '<label class="inline_label cls_gmb_margin">%1$s</label><span class="hint--top hint--top-multiline" aria-label="%2$s"><span 
+					class="dashicons gmb-tooltip-icon"></span></span>',
+				esc_html__( 'Map Theme', 'google-maps-builder' ),
+				esc_html__( 'Select an optional preconfigured Snazzy Maps style.', 'google-maps-builder' )
+			);
+			break;
 
 	}
 }


### PR DESCRIPTION
## Description
This PR will add Map Theme options tooltip which was lost while solving conflict.

## How Has This Been Tested?
Manually Tested

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation..